### PR TITLE
Make SimpleSwitch.init idempotent

### DIFF
--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -7,7 +7,9 @@ export {Switch};
 // Takes care of finding Switches within the site code.
 export var init = function() {
     var x, _switch,
-        switches = document.querySelectorAll("[data-type='simple-switch']");
+        switches = document.querySelectorAll(
+            "[data-type='simple-switch']:not(._simple-switch-checkbox)"
+        );
 
     for(x = 0; x < switches.length; x++) {
         _switch = switches[x];


### PR DESCRIPTION
Adding this `:not(._simple-switch-checkbox)` makes `init` idempotent (you can run it multiple times and it works the same as if you ran it only once). This is important for usage with libraries such as [htmx](https://htmx.org/) that swap in DOM elements after the initial page-load.